### PR TITLE
Update dockerd-wrapper

### DIFF
--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -63,6 +63,6 @@ exec dockerd \
 	--group "$default_socket_group" \
 	--exec-root="$SNAP_DATA/run/docker" \
 	--data-root="$SNAP_COMMON/var-lib-docker" \
-	--pidfile="$SNAP_DATA/run/docker.pid" \
+	--pidfile="/tmp/docker.pid" \
 	--config-file="$SNAP_DATA/config/daemon.json" \
 	"$@"

--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -45,11 +45,12 @@ rm -rf "$dir"
 trap - EXIT
 
 # modify XDG_RUNTIME_DIR to be a snap writable dir underneath $SNAP_COMMON 
-# until LP #1656340 is fixed
+# (until https://bugs.launchpad.net/snappy/+bug/1656340 is fixed)
 export XDG_RUNTIME_DIR=$SNAP_COMMON/run
 mkdir -p "$XDG_RUNTIME_DIR"
 
-# use SNAP_DATA for most "data" bits
+# use SNAP_COMMON for "/var/lib/docker" since it's common across snap revisions
+# (and typically gets large, so we don't want it backed up and restored like SNAP_DATA)
 mkdir -p "$SNAP_COMMON/var-lib-docker"
 
 # use "/run/snap.$SNAP_INSTANCE_NAME" for ephemeral storage

--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -47,13 +47,16 @@ trap - EXIT
 # modify XDG_RUNTIME_DIR to be a snap writable dir underneath $SNAP_COMMON 
 # until LP #1656340 is fixed
 export XDG_RUNTIME_DIR=$SNAP_COMMON/run
+mkdir -p "$XDG_RUNTIME_DIR"
 
 # use SNAP_DATA for most "data" bits
-mkdir -p \
-	"$SNAP_DATA/run" \
-	"/run/snap.$SNAP_INSTANCE_NAME" \
-	"$SNAP_COMMON/var-lib-docker" \
-	"$XDG_RUNTIME_DIR"
+mkdir -p "$SNAP_COMMON/var-lib-docker"
+
+# use "/run/snap.$SNAP_INSTANCE_NAME" for ephemeral storage
+# - https://github.com/snapcore/snapd/pull/6109
+# - https://github.com/docker-snap/docker-snap/pull/9
+run_dir="/run/snap.$SNAP_INSTANCE_NAME"
+mkdir -p "$run_dir"
 
 workaround_lp1606510
 
@@ -61,8 +64,8 @@ workaround_apparmor_profile_reload
 
 exec dockerd \
 	--group "$default_socket_group" \
-	--exec-root="/run/snap.$SNAP_INSTANCE_NAME" \
+	--exec-root="$run_dir" \
 	--data-root="$SNAP_COMMON/var-lib-docker" \
-	--pidfile="/run/snap.$SNAP_INSTANCE_NAME/docker.pid" \
+	--pidfile="$run_dir/docker.pid" \
 	--config-file="$SNAP_DATA/config/daemon.json" \
 	"$@"

--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -51,7 +51,7 @@ export XDG_RUNTIME_DIR=$SNAP_COMMON/run
 # use SNAP_DATA for most "data" bits
 mkdir -p \
 	"$SNAP_DATA/run" \
-	"$SNAP_DATA/run/docker" \
+	"/run/snap.$SNAP_INSTANCE_NAME" \
 	"$SNAP_COMMON/var-lib-docker" \
 	"$XDG_RUNTIME_DIR"
 
@@ -61,8 +61,8 @@ workaround_apparmor_profile_reload
 
 exec dockerd \
 	--group "$default_socket_group" \
-	--exec-root="$SNAP_DATA/run/docker" \
+	--exec-root="/run/snap.$SNAP_INSTANCE_NAME" \
 	--data-root="$SNAP_COMMON/var-lib-docker" \
-	--pidfile="/tmp/docker.pid" \
+	--pidfile="/run/snap.$SNAP_INSTANCE_NAME/docker.pid" \
 	--config-file="$SNAP_DATA/config/daemon.json" \
 	"$@"


### PR DESCRIPTION
Use `/run/snap.$SNAP_INSTANCE_NAME` for `docker.pid` and `exec-root` so that an unclean shutdown of the system does not leave a stale pidfile or other runtime-only files preventing Docker from starting up once the system is rebooted.

See: https://forum.snapcraft.io/t/docker-fails-to-restart-after-power-failure/19105/13