### PR TITLE
Add docker group instructions and certs info to description

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,33 +8,33 @@ This repository contains the source for the `docker` snap package.  The package 
 
 To install the latest stable release of Docker CE using `snap`:
 
-```
-$ sudo snap install docker
+```shell
+sudo snap install docker
 ```
 
 If you are using Ubuntu Core 16,
 
 * Connect the `docker:home` plug as it's not auto-connected by default:
 
-```
-$ sudo snap connect docker:home
+```shell
+sudo snap connect docker:home
 ```
 
 If you are using an alternative snap-compatible Linux distribution ("classic" in snap lingo), and would like to run `docker` as a normal user:
 
 * Create and join the `docker` group.
 
-```
-$ sudo addgroup --system docker
-$ sudo adduser $USER docker
-$ newgrp docker
+```shell
+sudo addgroup --system docker
+sudo adduser $USER docker
+newgrp docker
 ```
 
 * You will also need to disable and re-enable the `docker` snap if you added the group while it was running.
 
-```
-$ sudo snap disable docker
-$ sudo snap enable docker
+```shell
+sudo snap disable docker
+sudo snap enable docker
 ```
 
 ## Usage
@@ -45,7 +45,6 @@ Docker should function normally, with the following caveats:
 
   * If you are using Ubuntu Core 16, you'll need to work within a subfolder of `$HOME` that is readable by root. https://github.com/docker/docker-snap/issues/8
 
-* `docker-compose` is available as `docker.compose` due to snap naming restrictions.
 * Additional certificates used by the Docker daemon to authenticate with registries need to be located in `/var/snap/docker/common/etc/certs.d` instead of `/etc/docker/certs.d`.
 
 ### Examples
@@ -58,40 +57,40 @@ Developing the `docker` snap package is typically performed on a "classic" Ubunt
 
 * Install the snap tooling (requires `snapd>2.21` and `snapcraft>=2.26`):
 
-```
-$ sudo apt-get install snapd snapcraft
-$ sudo snap install core
+```shell
+sudo apt-get install snapd snapcraft
+sudo snap install core
 ```
 
 * Checkout this repository and build the `docker` snap package:
 
-```
-$ git clone https://github.com/docker/docker-snap
-$ cd docker-snap
-$ sudo snapcraft
+```shell
+git clone https://github.com/docker/docker-snap
+cd docker-snap
+sudo snapcraft
 ```
 
 * Install the newly-created snap package:
 
-```
-$ sudo snap install --dangerous docker_[VER]_[ARCH].snap
+```shell
+sudo snap install --dangerous docker_[VER]_[ARCH].snap
 ```
 
 * Manually connect the relevant plugs and slots which are not auto-connected:
 
-```
-$ sudo snap connect docker:privileged :docker-support
-$ sudo snap connect docker:support :docker-support
-$ sudo snap connect docker:firewall-control :firewall-control
-$ sudo snap connect docker:docker-cli docker:docker-daemon
-$ sudo snap disable docker
-$ sudo snap enable docker
+```shell
+sudo snap connect docker:privileged :docker-support
+sudo snap connect docker:support :docker-support
+sudo snap connect docker:firewall-control :firewall-control
+sudo snap connect docker:docker-cli docker:docker-daemon
+sudo snap disable docker
+sudo snap enable docker
 ```
 
   You should end up with output similar to:
 
-```
-$ sudo snap interfaces docker
+```shell
+sudo snap interfaces docker
     Slot                  Plug
     :docker-support       docker:privileged,docker:support
     :firewall-control     docker
@@ -102,6 +101,7 @@ $ sudo snap interfaces docker
 ```
 
 ## Testing
+
 We rely on spread (https://github.com/snapcore/spread) to run full-system test on Ubuntu Core 16. We also provide a utility script (run-spread-test.sh) to launch the spread test. It will
 
 1. Fetch primary snaps( kernel, core, gadget) and build custom Ubuntu Core image with them
@@ -111,30 +111,44 @@ We rely on spread (https://github.com/snapcore/spread) to run full-system test o
 
 Firstly, install ubuntu-image tool since we need to create a custom Ubuntu Core image during test preparation.
 
-    $ sudo snap install --beta --classic ubuntu-image
+```shell
+sudo snap install --beta --classic ubuntu-image
+```
 
 Secondly, install qemu-kvm package since we use it as the backend to run the spread test.
 
-    $ sudo apt install qemu-kvm
+```shell
+sudo apt install qemu-kvm
+```
 
 Meanwhile, you need a classic-mode supported spread binary to launch kvm from its context. You can either build spread from this [branch](https://github.com/rmescandon/spread/tree/snap-as-classic) or download the spread snap package [here](http://people.canonical.com/~gary-wzl77/spread_2017.05.24_amd64.snap).
 
-    $ sudo snap install --classic --dangerous spread_2017.05.24_amd64.snap
+```shell
+sudo snap install --classic --dangerous spread_2017.05.24_amd64.snap
+```
 
 You may build the docker snap locally in advance and then execute the spread tests with the following commands:
 
-    $ snapcraft
-    $ ./run-spread-tests.sh
+```shell
+snapcraft
+./run-spread-tests.sh
+```
 
 When doing a local build, you can also specify --test-from-channel to fetch the snap from the specific channel of the store. The snap from `candidate` channel is used by default as test target if `--channel` option is not specified.
 
-    $ ./run-spread-tests.sh --test-from-channel --channel=stable
+```shell
+./run-spread-tests.sh --test-from-channel --channel=stable
+```
 
 In order to run an individual spread test, please run the following command:
 
-    $ spread spread/main/installation
+```shell
+spread spread/main/installation
+```
 
 This will run the test case under spread/main/installation folder.
 You can specify the `SNAP_CHANNEL` environment variable to install a snap from a specific channel for the testing as well.
 
-    $ SNAP_CHANNEL=candidate spread spread/main/update_policy
+```shell
+SNAP_CHANNEL=candidate spread spread/main/update_policy
+```

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,8 +5,25 @@ summary: Docker container runtime
 description: |
   Build and run container images with Docker.
 
+  **Usage**
+
   * This build can only access files in the home directory. So Dockerfiles and all other files used in commands like `docker build`, `docker save` and `docker load` need to be in $HOME.
   * You can change the configuration of this build by modifying the files in `/var/snap/docker/current/`.
+  * Additional certificates used by the Docker daemon to authenticate with registries need to be added in `/var/snap/docker/common/etc/certs.d` (instead of `/etc/docker/certs.d`).
+
+  **Running Docker as normal user**
+
+  By default, Docker is only accessible with root privileges (`sudo`). If you want to use docker as a regular user, you need to add your user to the `docker` group.
+
+      sudo addgroup --system docker
+      sudo adduser $USER docker
+      newgrp docker
+      sudo snap disable docker
+      sudo snap enable docker
+
+  **Warning:** if you add your user to the `docker` group, it will have similar power as the `root` user. For details on how this impacts security in your system, see https://docs.docker.com/engine/security/#docker-daemon-attack-surface
+
+  **Authors**
 
   This snap is built by Canonical based on source code published by Docker, Inc. It is not endorsed or published by Docker, Inc.
 


### PR DESCRIPTION
This PR

* adds additional info to the description. This info was already available in the README but not in the description.
* removes the line about `docker.compose` from the readme (there seems to be an alias in place)
* fixes some linter errors in the readme

Note: my previous changes to the description did not propagate to the store page. This is probably because the description in the store was manually changed. You might need to run `snapcraft upload-metadata` explicitly before the metadata in the store will be changed.