### PR TITLE
Temporarily apply snapcraft patch for installing pip 20.x

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,6 +30,10 @@ jobs:
           sudo apt-get install -y snapcraft snapd
           sudo snap refresh
 
+          # TODO remove this hack once https://github.com/snapcore/snapcraft/pull/3429 is in a released snapcraft update in 16.04
+          wget -O "$HOME/snapcraft-pip-fix.patch" 'https://github.com/snapcore/snapcraft/pull/3429.patch'
+          sudo patch --directory=/usr/lib/python3/dist-packages --input="$HOME/snapcraft-pip-fix.patch" --strip=1
+
       - name: Build
         run: |
           env -i \


### PR DESCRIPTION
This manually applies https://github.com/snapcore/snapcraft/pull/3429 to `/usr/lib/python3/dist-packages/snapcraft/plugins/_python/_pip.py` inside our GitHub Actions build to hopefully make it work again (it's broken ATM because `plugin: python` installs pip 21 which then fails on Python 3.5 from Xenial).