### PR TITLE
Switch from detecting "pull_request" to detecting the origin repo

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -43,7 +43,8 @@ jobs:
             snapcraft snap --output docker.snap
 
       - name: Upload
-        if: github.event_name == 'pull_request'
+        # TODO the goal of this "if:" condition is to avoid creating artifacts on private forks (and using up all their storage quota), but Tianon couldn't find a clean way to do that so this was the next best thing
+        if: github.repository == 'docker-snap/docker-snap'
         uses: actions/upload-artifact@v2
         with:
           name: docker.snap


### PR DESCRIPTION
I wanted a "main" build today, but this prevented me from getting it (and the intent was to prevent this from running on private forks and filling up their meager free storage quotas), which I think this will do a better job of.