### PR TITLE
Update to "base: core18"

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -11,36 +11,26 @@ defaults:
 jobs:
   smoke-test:
     name: Snapcraft
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
       - name: Prep
         run: |
-          # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1604-README.md
+          # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
 
           # TODO figure out a better way to get Go and friends out of our path than dropping a nuke
           sudo rm -rf /opt/hostedtoolcache/*
 
-          sudo apt-get purge --auto-remove -y 'docker.*' 'moby.*'
+          sudo apt-get purge --auto-remove -y 'docker.*' 'containerd.*' 'moby.*' 'runc.*'
           sudo rm -rf /var/lib/docker /etc/docker /run/docker* /var/lib/containerd /run/containerd*
           sudo ip link delete docker0 || :
 
-          sudo apt-get update
-          sudo apt-get install -y snapcraft snapd
-          sudo snap refresh
-
-          # TODO remove this hack once https://github.com/snapcore/snapcraft/pull/3429 is in a released snapcraft update in 16.04
-          wget -O "$HOME/snapcraft-pip-fix.patch" 'https://github.com/snapcore/snapcraft/pull/3429.patch'
-          sudo patch --directory=/usr/lib/python3/dist-packages --input="$HOME/snapcraft-pip-fix.patch" --strip=1
-
       - name: Build
-        run: |
-          env -i \
-            PATH='/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
-            HOME='/tmp/home' \
-            GOCACHE='/tmp/gocache' \
-            snapcraft snap --output docker.snap
+        # https://github.com/snapcore/action-build/releases
+        uses: snapcore/action-build@v1.0.7
+        with:
+          snapcraft-args: snap --output docker.snap
 
       - name: Upload
         # TODO the goal of this "if:" condition is to avoid creating artifacts on private forks (and using up all their storage quota), but Tianon couldn't find a clean way to do that so this was the next best thing

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,17 +28,16 @@ description: |
   This snap is built by Canonical based on source code published by Docker, Inc. It is not endorsed or published by Docker, Inc.
 
   Docker and the Docker logo are trademarks or registered trademarks of Docker, Inc. in the United States and/or other countries. Docker, Inc. and other parties may also have trademark rights in other terms used herein.
-
-confinement: strict
+license: (Apache-2.0 AND MIT AND GPL-2.0)
 grade: stable
 
+base: core18
+confinement: strict
 assumes: [snapd2.40]
 
-passthrough:
-  license: (MIT AND Apache-2.0 AND GPL-2.0)
-  layout:
-    /etc/docker:
-      bind: $SNAP_DATA/etc/docker
+layout:
+  /etc/docker:
+    bind: $SNAP_DATA/etc/docker
 
 plugs:
   home:


### PR DESCRIPTION
Fixes #15

This will help us resolve things like https://github.com/snapcore/snapcraft/pull/3429 (which is currently blocking our ability to update the snap at all...) and hopefully let us use `stage-packages: git` instead of building our own bespoke `git` from source. :eyes: