### PR TITLE
Update "certs.d" paths

### DIFF
--- a/registry-example.md
+++ b/registry-example.md
@@ -39,10 +39,10 @@ These instructions are intended to get you started quickly using the open source
   * Copy the the certificate from the registry server to your client machine.
 
         $ scp user@registry_server_ip:/home/user/certs/domain.crt ./
-        $ sudo mkdir -p /var/snap/docker/common/etc/certs.d/mydockerhub.com:5000
-        $ sudo cp ./domain.crt /var/snap/docker/common/etc/certs.d/mydockerhub.com:5000/ca.crt
+        $ sudo mkdir -p /var/snap/docker/current/etc/docker/certs.d/mydockerhub.com:5000
+        $ sudo cp ./domain.crt /var/snap/docker/current/etc/docker/certs.d/mydockerhub.com:5000/ca.crt
 
-    > Note the special location `/var/snap/docker/common/etc/certs.d` instead of `/etc/docker/certs.d` mentioned in the [upstream documentation](https://docs.docker.com/engine/security/certificates/#understanding-the-configuration).
+    > Note the special location `/var/snap/docker/current/etc/docker/certs.d` instead of `/etc/docker/certs.d` mentioned in the [upstream documentation](https://docs.docker.com/engine/security/certificates/#understanding-the-configuration).
 
   * Login to the registry server:
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,7 +9,7 @@ description: |
 
   * This build can only access files in the home directory. So Dockerfiles and all other files used in commands like `docker build`, `docker save` and `docker load` need to be in $HOME.
   * You can change the configuration of this build by modifying the files in `/var/snap/docker/current/`.
-  * Additional certificates used by the Docker daemon to authenticate with registries need to be added in `/var/snap/docker/common/etc/certs.d` (instead of `/etc/docker/certs.d`).
+  * Additional certificates used by the Docker daemon to authenticate with registries need to be added in `/var/snap/docker/current/etc/docker/certs.d` (instead of `/etc/docker/certs.d`).
 
   **Running Docker as normal user**
 


### PR DESCRIPTION
This is technically a follow-up to 419af60dba5af78ff695217aaf55c8dd70c5592c, which removed the patch that enabled "/var/snap/docker/common/etc/certs.d"