### PR TITLE
Replace symlink with bind for /etc/docker

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,7 +37,7 @@ assumes: [snapd2.50]
 
 layout:
   /etc/docker:
-    symlink: $SNAP_DATA/etc/docker
+    bind: $SNAP_DATA/etc/docker
   /etc/gitconfig:
     bind-file: $SNAP_DATA/etc/gitconfig
   /usr/lib/git-core:


### PR DESCRIPTION
Fixes https://github.com/docker-snap/docker-snap/issues/45

We can't expect `/etc/docker` to be empty. This issue was introduced recently in https://github.com/docker-snap/docker-snap/pull/27/