### PR TITLE
update compose to 1.29.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -273,10 +273,10 @@ parts:
 
   compose:
     plugin: python
-    # https://github.com/docker/compose/blob/1.25.5/setup.py (Docker-supported Python versions)
+    # https://github.com/docker/compose/blob/1.29.2/setup.py (Docker-supported Python versions)
     python-version: python3
     source: https://github.com/docker/compose.git
-    source-tag: 1.25.5
+    source-tag: 1.29.2
     source-depth: 1
     build-packages:
       - libffi-dev


### PR DESCRIPTION
The currently used docker-compose is quite old. The major update is from 2019 (only bug fixes after that in the 1.25.x series). Since then there has been changes in the compose. Our project throws below error
```
docker-compose -f tools/docker_compose/docker-compose.yaml up
ERROR: The Compose file './tools/docker_compose/docker-compose.yaml' is invalid because:
Unsupported config option for services: 'bondy.docker'
make: *** [Makefile:8: devrunall] Error 1
```
However if I build the snap with latest docker-compose the issue is fixed