### PR TITLE
Update "snapcore/action-build" to v1.0.9

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build
         # https://github.com/snapcore/action-build/releases
-        uses: snapcore/action-build@v1.0.7
+        uses: snapcore/action-build@v1.0.9
         with:
           snapcraft-args: snap --output docker.snap
 


### PR DESCRIPTION
(Especially to avoid failing on `snap refresh lxd`)

https://github.com/snapcore/action-build/pull/24 :eyes:

See also https://forum.snapcraft.io/t/unexpectedly-empty-response-from-the-server/23393/16?u=tianon