### PR TITLE
Use registry:2.7.0 instead of broken registry:2

### DIFF
--- a/registry-example.md
+++ b/registry-example.md
@@ -16,7 +16,7 @@ These instructions are intended to get you started quickly using the open source
   * Create an `htpasswd` file, replacing "reguser" and "regpass" below with your desired credentials:
 
         $ cd $HOME && mkdir auth
-        $ sudo docker run --entrypoint htpasswd registry:2 -Bbn reguser regpass > auth/htpasswd
+        $ sudo docker run --entrypoint htpasswd httpd:2.4-alpine -Bbn reguser regpass > auth/htpasswd
 
   * Launch a basic authentication enabled registry server:
 


### PR DESCRIPTION
In the registry example, the code suggests using the `registry:2` image. However, the recent `registry` images (from 2.7.1 onwards) have suffered a regression due to a CVE ([documented here](https://github.com/docker/distribution-library-image/issues/106)) and the suggested commands fail. 

Version 2.7.0 still works. It does suffer from the aforementioned CVE, but that may not be terribly important for a simple example like this.