### PR TITLE
Add "compose-v2" plugin so "docker compose" works

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -79,6 +79,7 @@ jobs:
           sleep 1
           sudo docker version
           sudo docker info
+          sudo docker compose version
 
       - name: Save & Load
         run: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,6 +44,8 @@ layout:
     symlink: $SNAP/usr/lib/git-core
   /usr/share/git-core/templates:
     symlink: $SNAP/usr/share/git-core/templates
+  /usr/libexec/docker/cli-plugins:
+    symlink: $SNAP/usr/libexec/docker/cli-plugins
 
 plugs:
   home:
@@ -289,6 +291,21 @@ parts:
       - rustc
       - cargo
       - libssl-dev
+
+  compose-v2:
+    plugin: make
+    source: https://github.com/docker/compose.git
+    # https://github.com/docker/compose/releases
+    source-commit: v2.5.0
+    override-build: |
+      make -f builder.Makefile
+
+      install -d "$SNAPCRAFT_PART_INSTALL/usr/libexec/docker/cli-plugins"
+      install -T bin/docker-compose "$SNAPCRAFT_PART_INSTALL/usr/libexec/docker/cli-plugins/docker-compose"
+      # TODO remove "compose:" above and add a symlink from "$SNAPCRAFT_PART_INSTALL/bin/docker-compose" to this plugin (once v1 is fully EOL)
+    build-snaps: ['go/1.16/stable']
+    build-packages:
+      - make
 
   machine:
     plugin: make


### PR DESCRIPTION
The intention is to have this replace the standalone `docker-compose` / `docker.compose` command eventually too, but for now just having it available as `docker compose` is a good first step (and a good first plugin to embed).

Closes #69