### PR TITLE
Add curl to libnvidia-container parts

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -260,6 +260,7 @@ parts:
       craftctl default
     build-packages:
       - bmake
+      - curl
       - libelf-dev
       - libcap-dev
     # Paths taken from upstream packaging #


### PR DESCRIPTION
Launchpad base image doesn't include curl.

Failure logs:

 /bin/sh: 1: curl: not found

https://launchpadlibrarian.net/656730462/buildlog_snap_ubuntu_jammy_amd64_2c5566d9cd0fad66cd6d03c0241aa293_BUILDING.txt.gz