### PR TITLE
Add patch to use chroot mode in runc forcibly

### DIFF
--- a/patches/runc/chroot.patch
+++ b/patches/runc/chroot.patch
@@ -1,0 +1,19 @@
+diff --git a/libcontainer/rootfs_linux.go b/libcontainer/rootfs_linux.go
+index ec7638e4..629c6bad 100644
+--- a/libcontainer/rootfs_linux.go
++++ b/libcontainer/rootfs_linux.go
+@@ -135,13 +135,7 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig, mountFds []int) (err
+ 		return err
+ 	}
+ 
+-	if config.NoPivotRoot {
+-		err = msMoveRoot(config.Rootfs)
+-	} else if config.Namespaces.Contains(configs.NEWNS) {
+-		err = pivotRoot(config.Rootfs)
+-	} else {
+-		err = chroot()
+-	}
++	err = chroot()
+ 	if err != nil {
+ 		return fmt.Errorf("error jailing process inside rootfs: %w", err)
+ 	}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -204,11 +204,14 @@ parts:
     source-tag: v1.1.4
     source-depth: 1
     override-build: |
+      $CRAFT_STAGE/patches/patch.sh
+
       make BUILDTAGS='seccomp apparmor selinux' COMMIT=
 
       install -d "$CRAFT_PART_INSTALL/bin"
       install -T runc "$CRAFT_PART_INSTALL/bin/runc"
     build-snaps: *go
+    after: [wrapper-scripts]
     build-packages:
       - libapparmor-dev
       - libseccomp-dev


### PR DESCRIPTION
This is simliar to patches/engine/snappy-real-chroot.patch. Fixes #81