### PR TITLE
Drop default storage-driver, it is the same as autodetected/picked on…

### DIFF
--- a/config/daemon.json
+++ b/config/daemon.json
@@ -1,4 +1,3 @@
 {
     "log-level":        "error",
-    "storage-driver":   "overlay2"
 }

--- a/config/daemon.json
+++ b/config/daemon.json
@@ -1,3 +1,3 @@
 {
-    "log-level":        "error",
+    "log-level":        "error"
 }


### PR DESCRIPTION
…e anyway

Fixes: https://github.com/docker-snap/docker-snap/issues/112