### PR TITLE
NVIDIA support fixes

### DIFF
--- a/snap/hooks/connect-plug-graphics-core22
+++ b/snap/hooks/connect-plug-graphics-core22
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # Ensure nvidia support setup correctly #
-if snapctl is-connected nvidia-core22:graphics-core22 ; then
+if snapctl is-connected graphics-core22 ; then
 
     # Generate the CDI config #
     $SNAP/usr/bin/nvidia-ctk cdi generate --nvidia-ctk-path "$SNAP/usr/bin/nvidia-ctk" --output="$SNAP_DATA/etc/cdi/nvidia.yaml"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -13,7 +13,7 @@ mkdir -p "$SNAP_DATA/etc/docker"
 mkdir -p "$SNAP_DATA/etc/cdi"
 
 # Ensure nvidia support setup correctly #
-if snapctl is-connected nvidia-core22:graphics-core22 ; then
+if snapctl is-connected graphics-core22 ; then
 
     # Generate the CDI config #
     $SNAP/usr/bin/nvidia-ctk cdi generate --nvidia-ctk-path "$SNAP/usr/bin/nvidia-ctk" --output="$SNAP_DATA/etc/cdi/nvidia.yaml"

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -7,7 +7,7 @@ if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
 fi
 
 # Ensure nvidia support setup correctly #
-if snapctl is-connected nvidia-core22:graphics-core22 ; then
+if snapctl is-connected graphics-core22 ; then
 
     # Generate the CDI config #
     $SNAP/usr/bin/nvidia-ctk cdi generate --nvidia-ctk-path "$SNAP/usr/bin/nvidia-ctk" --output="$SNAP_DATA/etc/cdi/nvidia.yaml"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,6 +65,7 @@ plugs:
     privileged-containers: true
   docker-cli:
     interface: docker
+  opengl:
   # For nvidia userspace libs support #
   graphics-core22:
     interface: content

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -238,6 +238,7 @@ parts:
       bin: usr/bin/
     stage:
       - usr/bin/nvidia-container-*
+      - usr/bin/nvidia-ctk
 
   libnvidia-container:
     plugin: make


### PR DESCRIPTION
Somehow the interface connection test in the hooks was not configured correctly, and so the hooks were not running.  This fixes that.