### PR TITLE
NVIDIA opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,16 @@ Docker should function normally, with the following caveats:
 
 * Specifying the option `--security-opt="no-new-privileges=true"` with the `docker run` command (or the equivalent in docker-compose) will result in a failure of the container to start. This is due to an an underlying external constraint on AppArmor (see https://bugs.launchpad.net/snappy/+bug/1908448 for details).
 
+### Examples
+
+* [Setup a secure private registry](registry-example.md)
+
+
 ## NVIDIA support on Ubuntu Core 22
 
-If the system to found to have an NVIDIA graphics card available, the nvidia container toolkit will be setup and configured to enable use of the local GPU from docker.  This can be used to enable use of CUDA from a docker container, for instance.
+If the system is found to have an NVIDIA graphics card available, the nvidia container toolkit will be setup and configured to enable use of the local GPU from docker.  This can be used to enable use of CUDA from a docker container, for instance.
 
-This requires use the use connection of the graphics-core22 content interface provided by the nvidia-core22 snap, which should be automatically connected.
+This requires connection of the graphics-core22 content interface provided by the nvidia-core22 snap, which should be automatically connected.
 
 Example usage:
 
@@ -61,9 +66,12 @@ Example usage:
 docker run --rm --gpus all {cuda-container-image-name}
 ```
 
-### Examples
+### Disable NVIDIA support
 
-* [Setup a secure private registry](registry-example.md)
+Use of NVIDIA hardware or not should be automatic, but you may wish to specifically disable it.  You can do so via the following snap config:
+```shell
+snap set docker nvidia-support.disabled=true
+```
 
 ## Development
 

--- a/bin/nvidia-container-toolkit
+++ b/bin/nvidia-container-toolkit
@@ -33,6 +33,12 @@ NVIDIA_SUPPORT_DISABLED="$(snapctl get nvidia-support.disabled)"
 # Ensure nvidia support setup correctly, and only if hardware is preset and correct #
 if snapctl is-connected graphics-core22 ; then
 
+    # Connection hooks are run early - copy the config file from $SNAP into $SNAP_DATA if it doesn't exist
+    if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
+        mkdir -p "$SNAP_DATA/config"
+        cp "$SNAP/config/daemon.json" "$SNAP_DATA/config/daemon.json"
+    fi
+
     # Check if hardware is present - just exit if not #
     lspci -d 10de: | grep -q 'NVIDIA Corporation' || exit 0
     echo "NVIDIA hardware detected: $(lspci -d 10de:)"

--- a/bin/nvidia-container-toolkit
+++ b/bin/nvidia-container-toolkit
@@ -33,12 +33,13 @@ NVIDIA_SUPPORT_DISABLED="$(snapctl get nvidia-support.disabled)"
 # Ensure nvidia support setup correctly, and only if hardware is preset and correct #
 if snapctl is-connected graphics-core22 ; then
 
-    # If module is loaded - hardware _should_ be present #
-    grep -Eq "^nvidia" /proc/modules || exit 0
+    # Check if hardware is present - just exit if not #
+    lspci -d 10de: | grep -q 'NVIDIA Corporation' || exit 0
+    echo "NVIDIA hardware detected: $(lspci -d 10de:)"
 
     # As service order is not guaranteed outside of snap - wait a bit for nvidia assemble to complete #
     device_wait /dev/nvidiactl || exit 0
-    echo "NVIDIA detected"
+    echo "NVIDIA ready"
 
     # Ensure the layouts dir for /etc/cdi exists #
     mkdir -p "$SNAP_DATA/etc/cdi"

--- a/bin/nvidia-container-toolkit
+++ b/bin/nvidia-container-toolkit
@@ -26,6 +26,10 @@ device_wait() {
 
 }
 
+# Just exit if NVIDIA support is disabled #
+NVIDIA_SUPPORT_DISABLED="$(snapctl get nvidia-support.disabled)"
+[ "${NVIDIA_SUPPORT_DISABLED}" != "true" ] || exit 0
+
 # Ensure nvidia support setup correctly, and only if hardware is preset and correct #
 if snapctl is-connected graphics-core22 ; then
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -eux
+
+HOOK_LOG="${SNAP_COMMON}/hooks/${SNAP_REVISION}/$(basename "$0").log" && mkdir -p "${HOOK_LOG%/*}"
+exec &> >(tee -a "${HOOK_LOG}")
+
+# Flag to trigger service restart if any condition requires it #
+SVC_RESTART=false
+
+
+# Check if nvidia support is disabled #
+NVIDIA_SUPPORT_DISABLED="$(snapctl get nvidia-support.disabled)"
+
+if [ "${NVIDIA_SUPPORT_DISABLED}" == "true" ] ; then
+
+    # Remove nvidia runtime config, if it exists #
+    jq -r 'del(.runtimes.nvidia)' "${SNAP_DATA}/config/daemon.json" > "${SNAP_DATA}/config/daemon.json.new"
+
+    # If it was removed [ there was a change ], copy in the new config, remove CDI config,  and set service restart flag #
+    if ! cmp "${SNAP_DATA}/config/daemon.json"{,.new} >/dev/null ; then
+        mv "${SNAP_DATA}/config/daemon.json"{.new,}
+        rm -f "${SNAP_DATA}/etc/cdi/nvidia.yaml"
+        SVC_RESTART=true
+    fi
+
+fi
+
+# Restart services if required #
+# If oneshot services are inactive they don't respond to restart, so stop/start #
+if $SVC_RESTART ; then
+    snapctl stop "${SNAP_NAME}"
+    snapctl start "${SNAP_NAME}"
+fi

--- a/snap/hooks/connect-plug-graphics-core22
+++ b/snap/hooks/connect-plug-graphics-core22
@@ -1,4 +1,10 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -eu
+
+# Just exit if NVIDIA support is disabled #
+NVIDIA_SUPPORT_DISABLED="$(snapctl get nvidia-support.disabled)"
+[ "${NVIDIA_SUPPORT_DISABLED}" != "true" ] || exit 0
 
 # Ensure nvidia support setup correctly #
 if snapctl is-connected graphics-core22 ; then

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -146,6 +146,11 @@ parts:
       - bin/*
       - config/daemon.json
 
+  utils:
+    plugin: nil
+    stage-packages:
+      - jq
+
   engine:
     plugin: make
     source: https://github.com/moby/moby.git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -150,6 +150,7 @@ parts:
     plugin: nil
     stage-packages:
       - jq
+      - pciutils
 
   engine:
     plugin: make


### PR DESCRIPTION
Add the ability to completely op-out of setup up NVIDIA support, whether the hardware is present or not, by setting snap config.

By setting `nvidia-support.disabled=true` the daemon config file will have the nvidia runtime config remove, the CDI config for nvidia will be removed too, and the `nvidia-container-toolkit` service will be skipped.

This also improves the nvidia hardware detection, by checking for the presence of a PCI device with the relevant ID.

Fixes a bug effecting first install of this snap on a system.