### PR TITLE
Add simple smoke-test to ensure init is supported

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -103,6 +103,9 @@ jobs:
           [ "$actualOutput" = "$expectedOutput" ]
           docker rm test-journald
 
+      - name: Hello World (init)
+        run: sudo docker run --rm --init hello-world
+
       - name: Docker Build
         run: |
           sudo docker build --pull -t debian-hello - <<'EOF'


### PR DESCRIPTION
This adds a simple test to check for init support, and prevent the issue: https://github.com/docker-snap/docker-snap/issues/139