### PR TITLE
Improvements to snap refresh related to nvidia support 

### DIFF
--- a/bin/nvidia-container-toolkit
+++ b/bin/nvidia-container-toolkit
@@ -28,7 +28,7 @@ device_wait() {
 
 cdi_generate () {
     # Generate the CDI config #
-    "${SNAP}/usr/bin/nvidia-ctk" cdi generate --nvidia-ctk-path "${SNAP}/usr/bin/nvidia-ctk" --output="${SNAP_DATA}/etc/cdi/nvidia.yaml"
+    "${SNAP}/usr/bin/nvidia-ctk" cdi generate --nvidia-ctk-path "/snap/${SNAP_NAME}/current/usr/bin/nvidia-ctk" --output="${SNAP_DATA}/etc/cdi/nvidia.yaml"
 }
 
 runtime_configure () {

--- a/bin/nvidia-container-toolkit
+++ b/bin/nvidia-container-toolkit
@@ -36,8 +36,17 @@ runtime_configure () {
     "${SNAP}/usr/bin/nvidia-ctk" runtime configure --runtime=docker --runtime-path "${SNAP}/usr/bin/nvidia-ctk" --config "${SNAP_DATA}/config/daemon.json"
 }
 
-setup_warn () {
+setup_fail () {
     echo "WARNING: Conainter Toolkit setup seemed to fail with an error"
+
+    # Remove nvidia runtime config, if it exists #
+    jq -r 'del(.runtimes.nvidia)' "${SNAP_DATA}/config/daemon.json" > "${SNAP_DATA}/config/daemon.json.new"
+
+    # If it was removed [ there was a change ], copy in the new config, remove CDI config,  and set service restart flag #
+    if ! cmp "${SNAP_DATA}/config/daemon.json"{,.new} >/dev/null ; then
+        mv "${SNAP_DATA}/config/daemon.json"{.new,}
+        rm -f "${SNAP_DATA}/etc/cdi/nvidia.yaml"
+    fi
 }
 
 setup_info () {
@@ -69,6 +78,6 @@ if snapctl is-connected graphics-core22 ; then
     mkdir -p "$SNAP_DATA/etc/cdi"
 
     # Setup nvidia support, but do not exit on failure #
-    cdi_generate && runtime_configure && setup_info || setup_warn
+    cdi_generate && runtime_configure && setup_info || setup_fail
 
 fi

--- a/bin/nvidia-container-toolkit
+++ b/bin/nvidia-container-toolkit
@@ -26,6 +26,24 @@ device_wait() {
 
 }
 
+cdi_generate () {
+    # Generate the CDI config #
+    "${SNAP}/usr/bin/nvidia-ctk" cdi generate --nvidia-ctk-path "${SNAP}/usr/bin/nvidia-ctk" --output="${SNAP_DATA}/etc/cdi/nvidia.yaml"
+}
+
+runtime_configure () {
+    # Generate the dockerd runtime config #
+    "${SNAP}/usr/bin/nvidia-ctk" runtime configure --runtime=docker --runtime-path "${SNAP}/usr/bin/nvidia-ctk" --config "${SNAP_DATA}/config/daemon.json"
+}
+
+setup_warn () {
+    echo "WARNING: Conainter Toolkit setup seemed to fail with an error"
+}
+
+setup_info () {
+    echo "Conainter Toolkit setup complete"
+}
+
 # Just exit if NVIDIA support is disabled #
 NVIDIA_SUPPORT_DISABLED="$(snapctl get nvidia-support.disabled)"
 [ "${NVIDIA_SUPPORT_DISABLED}" != "true" ] || exit 0
@@ -50,12 +68,7 @@ if snapctl is-connected graphics-core22 ; then
     # Ensure the layouts dir for /etc/cdi exists #
     mkdir -p "$SNAP_DATA/etc/cdi"
 
-    # Generate the CDI config #
-    "${SNAP}/usr/bin/nvidia-ctk" cdi generate --nvidia-ctk-path "${SNAP}/usr/bin/nvidia-ctk" --output="${SNAP_DATA}/etc/cdi/nvidia.yaml"
-
-    # Generate the dockerd runtime config #
-    "${SNAP}/usr/bin/nvidia-ctk" runtime configure --runtime=docker --runtime-path "${SNAP}/usr/bin/nvidia-ctk" --config "${SNAP_DATA}/config/daemon.json"
-
-    echo "Conainter Toolkit setup complete"
+    # Setup nvidia support, but do not exit on failure #
+    cdi_generate && runtime_configure && setup_info || setup_warn
 
 fi

--- a/bin/nvidia-container-toolkit
+++ b/bin/nvidia-container-toolkit
@@ -28,7 +28,7 @@ device_wait() {
 
 cdi_generate () {
     # Generate the CDI config #
-    "${SNAP}/usr/bin/nvidia-ctk" cdi generate --nvidia-ctk-path "/snap/${SNAP_NAME}/current/usr/bin/nvidia-ctk" --output="${SNAP_DATA}/etc/cdi/nvidia.yaml"
+    "${SNAP}/usr/bin/nvidia-ctk" cdi generate --nvidia-ctk-path "/snap/${SNAP_NAME}/current/usr/bin/nvidia-ctk" --output "${SNAP_DATA}/etc/cdi/nvidia.yaml"
 }
 
 runtime_configure () {

--- a/bin/nvidia-container-toolkit
+++ b/bin/nvidia-container-toolkit
@@ -33,7 +33,7 @@ cdi_generate () {
 
 runtime_configure () {
     # Generate the dockerd runtime config #
-    "${SNAP}/usr/bin/nvidia-ctk" runtime configure --runtime=docker --runtime-path "${SNAP}/usr/bin/nvidia-ctk" --config "${SNAP_DATA}/config/daemon.json"
+    "${SNAP}/usr/bin/nvidia-ctk" runtime configure --runtime=docker --runtime-path "/snap/${SNAP_NAME}/current/usr/bin/nvidia-ctk" --config "${SNAP_DATA}/config/daemon.json"
 }
 
 setup_fail () {

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -5,6 +5,3 @@ if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
     mkdir -p "$SNAP_DATA/config"
     cp "$SNAP/config/daemon.json" "$SNAP_DATA/config/daemon.json"
 fi
-
-# Should should always be re-craeted if required, as it contains paths based on snap revision #
-rm -f "${SNAP_DATA}/etc/cdi/nvidia.yaml"

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -5,3 +5,6 @@ if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
     mkdir -p "$SNAP_DATA/config"
     cp "$SNAP/config/daemon.json" "$SNAP_DATA/config/daemon.json"
 fi
+
+# Should should always be re-craeted if required, as it contains paths based on snap revision #
+rm -f "${SNAP_DATA}/etc/cdi/nvidia.yaml"


### PR DESCRIPTION
This addresses two current known issues to snap refresh if nvidia support is in use.

The previous CDI config is never valid for a newer revision, as some paths contain the snap revision.
- This PR ensures the previous config is always purged

If the `nvidia-container-toolkit` service fails to start properly for some reason, it prevents the snap refresh from completing, even though dockerd would remain functional for non nvidia images use cases.
- This PR enables `nvidia-container-toolkit` to fail setting up the CDI and dockerd config, and print a warning instead.
- It also ensures that dockerd config is only attempted if CDI config is generated.
- CDI config can fail on refresh due to: `ERROR_LIB_RM_VERSION_MISMATCH` [ nvidia kernel module and user space libs do not match ].