### PR TITLE
Add option to use nvidia runtime by default

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,6 +113,7 @@ apps:
       - privileged
       - support
       - graphics-core22
+      - system-observe
     slots:
       - docker-daemon
 


### PR DESCRIPTION
For some use cases it's desirable to set the nvidia runtime to default.

This will is a daemon config option, which will be set by snap config.

Requires enabling full use of nvidia runtime.  All previous testing has just been using the `--gpu` docker-run flag only, which does enable use of CUDA docker containers, but it seems to work slightly differently than using the nvidia runtime instead of runc.

New interfaces required:
- system-observe
