### PR TITLE
Nvidia runtime default

### DIFF
--- a/bin/nvidia-container-toolkit
+++ b/bin/nvidia-container-toolkit
@@ -33,7 +33,7 @@ cdi_generate () {
 
 runtime_configure () {
     # Generate the dockerd runtime config #
-    "${SNAP}/usr/bin/nvidia-ctk" runtime configure --runtime=docker --runtime-path "/snap/${SNAP_NAME}/current/usr/bin/nvidia-ctk" --config "${SNAP_DATA}/config/daemon.json"
+    "${SNAP}/usr/bin/nvidia-ctk" runtime configure --runtime=docker --runtime-path "/snap/${SNAP_NAME}/current/usr/bin/nvidia-container-runtime" --config "${SNAP_DATA}/config/daemon.json"
 }
 
 setup_fail () {

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -6,5 +6,6 @@ if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
     cp "$SNAP/config/daemon.json" "$SNAP_DATA/config/daemon.json"
 fi
 
-# ensure the layouts dir for /etc/docker exists
+# ensure the layouts dir for /etc/{stuff} exists
 mkdir -p "$SNAP_DATA/etc/docker"
+mkdir -p "$SNAP_DATA/etc/nvidia-container-runtime"

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,5 +1,9 @@
 #!/bin/bash -e
 
+# ensure the layouts dir for /etc/{stuff} exists
+mkdir -p "$SNAP_DATA/etc/docker"
+mkdir -p "$SNAP_DATA/etc/nvidia-container-runtime"
+
 # copy the config file from $SNAP into $SNAP_DATA if it doesn't exist
 if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
     mkdir -p "$SNAP_DATA/config"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -115,8 +115,7 @@ apps:
       - privileged
       - support
       - graphics-core22
-      # FIXME: check `system-observe` is really required
-      - system-observe
+      - system-observe # Seems funtional without - but it generates quite a bit of noise in audit logs - can be manually connected
     slots:
       - docker-daemon
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,6 +46,8 @@ layout:
   # Container Device Interface (CDI) Support - https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#container-device-interface-cdi-support
   /etc/cdi:
     bind: $SNAP_DATA/etc/cdi
+  /etc/nvidia-container-runtime:
+    bind: $SNAP_DATA/etc/nvidia-container-runtime
   /etc/gitconfig:
     bind-file: $SNAP_DATA/etc/gitconfig
   /usr/libexec/docker/cli-plugins:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -115,6 +115,7 @@ apps:
       - privileged
       - support
       - graphics-core22
+      # FIXME: check `system-observe` is really required
       - system-observe
     slots:
       - docker-daemon

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -115,7 +115,6 @@ apps:
       - privileged
       - support
       - graphics-core22
-      - system-observe # Seems funtional without - but it generates quite a bit of noise in audit logs - can be manually connected
     slots:
       - docker-daemon
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,6 +113,7 @@ apps:
       - privileged
       - support
       - graphics-core22
+      - system-observe
     slots:
       - docker-daemon
 


### PR DESCRIPTION
Fix bug in runtime config
    
Should be nvidia-container-runtime binary, not nvidia-ctk
    
NVIDIA GPU support works without using the full nvidia-container-runtime,
but in some cases it turns out that switching to the
nvidia-container-runtime entirely is beneficial [ ability to schedule multiple simultaneous GPU containers ]

Example usage:
```
docker run --rm --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all {image-name} {container-name}
```