### PR TITLE
NVIDIA support - improvements relating to runtime config and CDI

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,40 @@ Docker should function normally, with the following caveats:
 
 ## NVIDIA support on Ubuntu Core 22
 
-If the system is found to have an NVIDIA graphics card available, the nvidia container toolkit will be setup and configured to enable use of the local GPU from docker.  This can be used to enable use of CUDA from a docker container, for instance.
+If the system is found to have an nvidia graphics card available, the nvidia container toolkit will be setup and configured to enable use of the local GPU from docker.  This can be used to enable use of CUDA from a docker container, for instance.
 
-This requires connection of the graphics-core22 content interface provided by the nvidia-core22 snap, which should be automatically connected.
+This requires connection of the graphics-core22 content interface provided by the nvidia-core22 snap, which should be automatically connected once installed.
+
+To enable proper use of the GPU within docker, the nvidia runtime must be used.  By default, the nvidia runtime will be configured to use ([CDI](https://github.com/cncf-tags/container-device-interface)) mode, and a the appropriate nvidia CDI config will be automatically created for the system.  You just need to specify the nvidia runtime when running a container.
 
 Example usage:
 
 ```shell
-docker run --rm --gpus all {cuda-container-image-name}
+docker run --rm --runtime nvidia {cuda-container-image-name}
+```
+
+### Custom NVIDIA runtime config
+
+If you want to make some adjustments to the automatically generated runtime config, you can use the `nvidia-support.runtime.config-override` snap config to completely replace it.
+
+```shell
+snap set docker nvidia-support.runtime.config-override="$(cat cutom-nvidia-config.toml)"
+```
+
+### CDI device naming strategy
+
+By default, the `device-name-strategy` for the CDI config will use `index`.  Optionally, you can specify an alternative from the currently supported:
+* `index`
+* `uuid`
+* `type-index`
+
+```shell
+snap set docker nvidia-support.cdi.device-name-strategy=uuid
 ```
 
 ### Disable NVIDIA support
 
-Use of NVIDIA hardware or not should be automatic, but you may wish to specifically disable it.  You can do so via the following snap config:
+Setting up the nvidia support should be automatic the hardware is present, but you may wish to specifically disable it so that setup is not even attempted.  You can do so via the following snap config:
 ```shell
 snap set docker nvidia-support.disabled=true
 ```

--- a/bin/nvidia-container-toolkit
+++ b/bin/nvidia-container-toolkit
@@ -35,7 +35,11 @@ device_wait() {
 
 # Generate the CDI config #
 cdi_generate () {
-    "${SNAP}/usr/bin/nvidia-ctk" cdi generate --nvidia-ctk-path "/snap/${SNAP_NAME}/current/usr/bin/nvidia-ctk" --library-search-path "${SNAP}/graphics/lib/${ARCH_TRIPLET}" --output "${SNAP_DATA}/etc/cdi/nvidia.yaml"
+    # Allow configred device-name-strategy, or default to index [ default in nvidia-ctk ] #
+    CDI_DEVICE_NAME_STRATEGY="$(snapctl get nvidia-support.cdi.device-name-strategy)"
+    CDI_DEVICE_NAME_STRATEGY="${CDI_DEVICE_NAME_STRATEGY:-index}"
+
+    "${SNAP}/usr/bin/nvidia-ctk" cdi generate --nvidia-ctk-path "/snap/${SNAP_NAME}/current/usr/bin/nvidia-ctk" --library-search-path "${SNAP}/graphics/lib/${ARCH_TRIPLET}" --device-name-strategy "${CDI_DEVICE_NAME_STRATEGY}" --output "${SNAP_DATA}/etc/cdi/nvidia.yaml"
 }
 
 # Create the nvidia runtime config, either snap default or custom #

--- a/bin/nvidia-container-toolkit
+++ b/bin/nvidia-container-toolkit
@@ -2,6 +2,13 @@
 
 set -eu
 
+U_MACHINE="$(uname -m)"
+U_OS="$(uname -o)"
+U_KERNEL="${U_OS##*/}"
+U_USERLAND="${U_OS%%/*}"
+
+ARCH_TRIPLET="${U_MACHINE}-${U_KERNEL,,}-${U_USERLAND,,}"
+
 device_wait() {
 
     COUNT=0
@@ -26,16 +33,31 @@ device_wait() {
 
 }
 
+# Generate the CDI config #
 cdi_generate () {
-    # Generate the CDI config #
-    "${SNAP}/usr/bin/nvidia-ctk" cdi generate --nvidia-ctk-path "/snap/${SNAP_NAME}/current/usr/bin/nvidia-ctk" --output "${SNAP_DATA}/etc/cdi/nvidia.yaml"
+    "${SNAP}/usr/bin/nvidia-ctk" cdi generate --nvidia-ctk-path "/snap/${SNAP_NAME}/current/usr/bin/nvidia-ctk" --library-search-path "${SNAP}/graphics/lib/${ARCH_TRIPLET}" --output "${SNAP_DATA}/etc/cdi/nvidia.yaml"
 }
 
-runtime_configure () {
-    # Generate the dockerd runtime config #
+# Create the nvidia runtime config, either snap default or custom #
+nvidia_runtime_config () {
+    RUNTIME_CONFIG_OVERRIDE="$(snapctl get nvidia-support.runtime.config-override)"
+
+    # Custom #
+    if [ -n "${RUNTIME_CONFIG_OVERRIDE}" ] ; then
+        echo "${RUNTIME_CONFIG_OVERRIDE}" > "${SNAP_DATA}/etc/nvidia-container-runtime/config.toml"
+    # Default - opinionated, but most viable option for now #
+    else
+        rm -f "${SNAP_DATA}/etc/nvidia-container-runtime/config.toml"
+        "${SNAP}/usr/bin/nvidia-ctk" config --in-place --set nvidia-container-runtime.mode=cdi
+    fi
+}
+
+# Generate the dockerd runtime config #
+docker_runtime_configure () {
     "${SNAP}/usr/bin/nvidia-ctk" runtime configure --runtime=docker --runtime-path "/snap/${SNAP_NAME}/current/usr/bin/nvidia-container-runtime" --config "${SNAP_DATA}/config/daemon.json"
 }
 
+# Setup failure recovery #
 setup_fail () {
     echo "WARNING: Conainter Toolkit setup seemed to fail with an error"
 
@@ -46,9 +68,11 @@ setup_fail () {
     if ! cmp "${SNAP_DATA}/config/daemon.json"{,.new} >/dev/null ; then
         mv "${SNAP_DATA}/config/daemon.json"{.new,}
         rm -f "${SNAP_DATA}/etc/cdi/nvidia.yaml"
+        rm -f "${SNAP_DATA}/etc/nvidia-container-runtime/config.toml"
     fi
 }
 
+# Info #
 setup_info () {
     echo "Conainter Toolkit setup complete"
 }
@@ -74,10 +98,11 @@ if snapctl is-connected graphics-core22 ; then
     device_wait /dev/nvidiactl || exit 0
     echo "NVIDIA ready"
 
-    # Ensure the layouts dir for /etc/cdi exists #
-    mkdir -p "$SNAP_DATA/etc/cdi"
+    # Ensure the layout dirs for cdi exists #
+    mkdir -p "${SNAP_DATA}/etc/cdi"
+    mkdir -p "${SNAP_DATA}/etc/nvidia-container-runtime"
 
     # Setup nvidia support, but do not exit on failure #
-    cdi_generate && runtime_configure && setup_info || setup_fail
+    cdi_generate && nvidia_runtime_config && docker_runtime_configure && setup_info || setup_fail
 
 fi

--- a/bin/nvidia-container-toolkit
+++ b/bin/nvidia-container-toolkit
@@ -39,7 +39,7 @@ cdi_generate () {
     CDI_DEVICE_NAME_STRATEGY="$(snapctl get nvidia-support.cdi.device-name-strategy)"
     CDI_DEVICE_NAME_STRATEGY="${CDI_DEVICE_NAME_STRATEGY:-index}"
 
-    "${SNAP}/usr/bin/nvidia-ctk" cdi generate --nvidia-ctk-path "/snap/${SNAP_NAME}/current/usr/bin/nvidia-ctk" --library-search-path "${SNAP}/graphics/lib/${ARCH_TRIPLET}" --device-name-strategy "${CDI_DEVICE_NAME_STRATEGY}" --output "${SNAP_DATA}/etc/cdi/nvidia.yaml"
+    "${SNAP}/usr/bin/nvidia-ctk" cdi generate --nvidia-ctk-path "${SNAP}/usr/bin/nvidia-ctk" --library-search-path "${SNAP}/graphics/lib/${ARCH_TRIPLET}" --device-name-strategy "${CDI_DEVICE_NAME_STRATEGY}" --output "${SNAP_DATA}/etc/cdi/nvidia.yaml"
 }
 
 # Create the nvidia runtime config, either snap default or custom #
@@ -58,7 +58,7 @@ nvidia_runtime_config () {
 
 # Generate the dockerd runtime config #
 docker_runtime_configure () {
-    "${SNAP}/usr/bin/nvidia-ctk" runtime configure --runtime=docker --runtime-path "/snap/${SNAP_NAME}/current/usr/bin/nvidia-container-runtime" --config "${SNAP_DATA}/config/daemon.json"
+    "${SNAP}/usr/bin/nvidia-ctk" runtime configure --runtime=docker --runtime-path "${SNAP}/usr/bin/nvidia-container-runtime" --config "${SNAP_DATA}/config/daemon.json"
 }
 
 # Setup failure recovery #

--- a/nvidia/lib
+++ b/nvidia/lib
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -eu
+# nvidia toolkit related setup funtions #
 
 U_MACHINE="$(uname -m)"
 U_OS="$(uname -o)"
@@ -8,6 +6,8 @@ U_KERNEL="${U_OS##*/}"
 U_USERLAND="${U_OS%%/*}"
 
 ARCH_TRIPLET="${U_MACHINE}-${U_KERNEL,,}-${U_USERLAND,,}"
+
+NVIDIA_SUPPORT_DISABLED="$(snapctl get nvidia-support.disabled)"
 
 device_wait() {
 
@@ -33,13 +33,25 @@ device_wait() {
 
 }
 
+# Check if hardware is present - just exit if not #
+nvidia_hw_ensure() {
+    lspci -d 10de: | grep -q 'NVIDIA Corporation' || exit 0
+    echo "NVIDIA hardware detected: $(lspci -d 10de:)"
+}
+
+# Create any data dirs if missing #
+ensure_nvidia_data_dirs() {
+    mkdir -p "${SNAP_DATA}/etc/cdi"
+    mkdir -p "${SNAP_DATA}/etc/nvidia-container-runtime"
+}
+
 # Generate the CDI config #
 cdi_generate () {
-    # Allow configred device-name-strategy, or default to index [ default in nvidia-ctk ] #
+    # Allow configured device-name-strategy, or default to index [ default in nvidia-ctk ] #
     CDI_DEVICE_NAME_STRATEGY="$(snapctl get nvidia-support.cdi.device-name-strategy)"
     CDI_DEVICE_NAME_STRATEGY="${CDI_DEVICE_NAME_STRATEGY:-index}"
 
-    "${SNAP}/usr/bin/nvidia-ctk" cdi generate --nvidia-ctk-path "${SNAP}/usr/bin/nvidia-ctk" --library-search-path "${SNAP}/graphics/lib/${ARCH_TRIPLET}" --device-name-strategy "${CDI_DEVICE_NAME_STRATEGY}" --output "${SNAP_DATA}/etc/cdi/nvidia.yaml"
+    PATH="${PATH}:${SNAP}/graphics/bin" "${SNAP}/usr/bin/nvidia-ctk" cdi generate --nvidia-ctk-path "${SNAP}/usr/bin/nvidia-ctk" --library-search-path "${SNAP}/graphics/lib/${ARCH_TRIPLET}" --device-name-strategy "${CDI_DEVICE_NAME_STRATEGY}" --output "${SNAP_DATA}/etc/cdi/nvidia.yaml"
 }
 
 # Create the nvidia runtime config, either snap default or custom #
@@ -80,33 +92,3 @@ setup_fail () {
 setup_info () {
     echo "Conainter Toolkit setup complete"
 }
-
-# Just exit if NVIDIA support is disabled #
-NVIDIA_SUPPORT_DISABLED="$(snapctl get nvidia-support.disabled)"
-[ "${NVIDIA_SUPPORT_DISABLED}" != "true" ] || exit 0
-
-# Ensure nvidia support setup correctly, and only if hardware is preset and correct #
-if snapctl is-connected graphics-core22 ; then
-
-    # Connection hooks are run early - copy the config file from $SNAP into $SNAP_DATA if it doesn't exist
-    if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
-        mkdir -p "$SNAP_DATA/config"
-        cp "$SNAP/config/daemon.json" "$SNAP_DATA/config/daemon.json"
-    fi
-
-    # Check if hardware is present - just exit if not #
-    lspci -d 10de: | grep -q 'NVIDIA Corporation' || exit 0
-    echo "NVIDIA hardware detected: $(lspci -d 10de:)"
-
-    # As service order is not guaranteed outside of snap - wait a bit for nvidia assemble to complete #
-    device_wait /dev/nvidiactl || exit 0
-    echo "NVIDIA ready"
-
-    # Ensure the layout dirs for cdi exists #
-    mkdir -p "${SNAP_DATA}/etc/cdi"
-    mkdir -p "${SNAP_DATA}/etc/nvidia-container-runtime"
-
-    # Setup nvidia support, but do not exit on failure #
-    cdi_generate && nvidia_runtime_config && docker_runtime_configure && setup_info || setup_fail
-
-fi

--- a/nvidia/nvidia-container-toolkit
+++ b/nvidia/nvidia-container-toolkit
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -eu
+
+. "${SNAP}/usr/share/nvidia-container-toolkit/lib"
+
+# Just exit if NVIDIA support is disabled #
+[ "${NVIDIA_SUPPORT_DISABLED}" != "true" ] || exit 0
+
+# Ensure nvidia support setup correctly, and only if hardware is preset and correct #
+if snapctl is-connected graphics-core22 ; then
+
+    # Connection hooks are run early - copy the config file from $SNAP into $SNAP_DATA if it doesn't exist
+    if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
+        mkdir -p "$SNAP_DATA/config"
+        cp "$SNAP/config/daemon.json" "$SNAP_DATA/config/daemon.json"
+    fi
+
+    # Ensure hardware present #
+    nvidia_hw_ensure
+
+    # As service order is not guaranteed outside of snap - wait a bit for nvidia assemble to complete #
+    device_wait /dev/nvidiactl || exit 0
+    echo "NVIDIA ready"
+
+    # Ensure the data dirs exist #
+    ensure_nvidia_data_dirs
+
+    # Setup nvidia support, but do not exit on failure #
+    cdi_generate && nvidia_runtime_config && docker_runtime_configure && setup_info || setup_fail
+
+fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -5,12 +5,10 @@ set -eux
 HOOK_LOG="${SNAP_COMMON}/hooks/${SNAP_REVISION}/$(basename "$0").log" && mkdir -p "${HOOK_LOG%/*}"
 exec &> >(tee -a "${HOOK_LOG}")
 
+. "${SNAP}/usr/share/nvidia-container-toolkit/lib"
+
 # Flag to trigger service restart if any condition requires it #
 SVC_RESTART=false
-
-
-# Check if nvidia support is disabled #
-NVIDIA_SUPPORT_DISABLED="$(snapctl get nvidia-support.disabled)"
 
 if [ "${NVIDIA_SUPPORT_DISABLED}" == "true" ] ; then
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -21,6 +21,7 @@ if [ "${NVIDIA_SUPPORT_DISABLED}" == "true" ] ; then
     if ! cmp "${SNAP_DATA}/config/daemon.json"{,.new} >/dev/null ; then
         mv "${SNAP_DATA}/config/daemon.json"{.new,}
         rm -f "${SNAP_DATA}/etc/cdi/nvidia.yaml"
+        rm -f "${SNAP_DATA}/etc/nvidia-container-runtime/config.toml"
         SVC_RESTART=true
     fi
 
@@ -31,4 +32,8 @@ fi
 if $SVC_RESTART ; then
     snapctl stop "${SNAP_NAME}"
     snapctl start "${SNAP_NAME}"
+# Otherwise, just restart the nvidia-container-toolkit #
+else
+    snapctl stop "${SNAP_NAME}.nvidia-container-toolkit"
+    snapctl start "${SNAP_NAME}.nvidia-container-toolkit"
 fi

--- a/snap/hooks/connect-plug-graphics-core22
+++ b/snap/hooks/connect-plug-graphics-core22
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-set -eu
+set -eux
+
+HOOK_LOG="${SNAP_COMMON}/hooks/${SNAP_REVISION}/$(basename "$0").log" && mkdir -p "${HOOK_LOG%/*}"
+exec &> >(tee -a "${HOOK_LOG}")
 
 # Just exit if NVIDIA support is disabled #
 NVIDIA_SUPPORT_DISABLED="$(snapctl get nvidia-support.disabled)"
@@ -15,8 +18,9 @@ if snapctl is-connected graphics-core22 ; then
     echo "NVIDIA detected"
 
     # Restart services to reflect any changes if required #
-    # Have to called by name - nvidia-container-toolkik is inactive and won't be included with just snap name #
-    snapctl restart "${SNAP_NAME}.nvidia-container-toolkit"
+    # If oneshot services are inactive they don't respond to restart, so stop/start #
+    snapctl stop "${SNAP_NAME}.nvidia-container-toolkit"
+    snapctl start "${SNAP_NAME}.nvidia-container-toolkit"
     snapctl restart "${SNAP_NAME}.dockerd"
 
 fi

--- a/snap/hooks/connect-plug-graphics-core22
+++ b/snap/hooks/connect-plug-graphics-core22
@@ -5,17 +5,19 @@ set -eux
 HOOK_LOG="${SNAP_COMMON}/hooks/${SNAP_REVISION}/$(basename "$0").log" && mkdir -p "${HOOK_LOG%/*}"
 exec &> >(tee -a "${HOOK_LOG}")
 
+. "${SNAP}/usr/share/nvidia-container-toolkit/lib"
+
 # Just exit if NVIDIA support is disabled #
-NVIDIA_SUPPORT_DISABLED="$(snapctl get nvidia-support.disabled)"
 [ "${NVIDIA_SUPPORT_DISABLED}" != "true" ] || exit 0
 
 # Ensure nvidia support setup correctly #
 if snapctl is-connected graphics-core22 ; then
 
-    # Only set this up if the system has an nvidia card available #
-    grep -Eq "^nvidia" /proc/modules || exit 0
-    test -c /dev/nvidiactl || exit 0
+    # Ensure hardware present #
     echo "NVIDIA detected"
+
+    # Ensure hardware present #
+    nvidia_hw_ensure
 
     # Restart services to reflect any changes if required #
     # If oneshot services are inactive they don't respond to restart, so stop/start #

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,11 +1,15 @@
-#!/bin/bash -e
+#!/bin/bash
 
-# copy the config file from $SNAP into $SNAP_COMMON if it doesn't exist
-if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
-    mkdir -p "$SNAP_DATA/config"
-    cp "$SNAP/config/daemon.json" "$SNAP_DATA/config/daemon.json"
-fi
+set -eu
+
+. "${SNAP}/usr/share/nvidia-container-toolkit/lib"
 
 # ensure the layouts dir for /etc/{stuff} exists
 mkdir -p "$SNAP_DATA/etc/docker"
-mkdir -p "$SNAP_DATA/etc/nvidia-container-runtime"
+mkdir -p "$SNAP_DATA/config"
+ensure_nvidia_data_dirs
+
+# copy the config file from $SNAP into $SNAP_DATA if it doesn't exist
+if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
+    cp "$SNAP/config/daemon.json" "$SNAP_DATA/config/daemon.json"
+fi

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,11 +1,1 @@
-#!/bin/bash -e
-
-# ensure the layouts dir for /etc/{stuff} exists
-mkdir -p "$SNAP_DATA/etc/docker"
-mkdir -p "$SNAP_DATA/etc/nvidia-container-runtime"
-
-# copy the config file from $SNAP into $SNAP_DATA if it doesn't exist
-if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
-    mkdir -p "$SNAP_DATA/config"
-    cp "$SNAP/config/daemon.json" "$SNAP_DATA/config/daemon.json"
-fi
+install

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -147,15 +147,20 @@ parts:
     source: .
     stage-packages:
       - mount
+    organize:
+      nvidia/lib: usr/share/nvidia-container-toolkit/lib
+      nvidia/nvidia-container-toolkit: bin/
     stage:
       - bin/*
       - config/daemon.json
       - patches/*
+      - usr/share/nvidia-container-toolkit/*
     prime:
       - -bin/go-build-helper.sh
       - -patches/*
       - bin/*
       - config/daemon.json
+      - usr/share/nvidia-container-toolkit/*
 
   utils:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -251,7 +251,7 @@ parts:
   nvidia-container-toolkit:
     plugin: go
     source: https://github.com/NVIDIA/nvidia-container-toolkit.git
-    source-tag: v1.13.5
+    source-tag: v1.15.0
     source-depth: 1
     override-pull: &arch-restrict |
       [ "${CRAFT_TARGET_ARCH}" != "amd64" ] && \
@@ -274,7 +274,7 @@ parts:
   libnvidia-container:
     plugin: make
     source: https://github.com/NVIDIA/libnvidia-container.git
-    source-tag: v1.13.5
+    source-tag: v1.15.0
     source-depth: 1
     override-pull: *arch-restrict
     override-build: *arch-restrict


### PR DESCRIPTION
This enhances the nvidia runtime configuration and support, and enforces use of CDI by default.

After the versions of nvidia related parts were increased to `13.5` , the CDI generation was broken.  This led to a deeper review of the nvidia runtime configuration options, and some resulting proposed enhancements.  This also included raising a bug in the nvidia-container-toolkit, which resulted in the introduction of specified support for `library-search-paths`, which fixes the CDI generation to properly support Ubuntu Core, which will land in the `v1.15.0` release.
* https://github.com/NVIDIA/nvidia-container-toolkit/issues/82

Summary of changes:
* Bump nvidia toolkit version to `v1.15.0`
* Use CDI by default
* Ensure CDI config properly generated
* Enable choice of CDI device-name-strategy via snap config
* Enable manual config override of nvidia runtime config via snap config
* Centralise nvidia related shell functions to reduce duplicated code and make scripts more readable
* Updated README to reflect recent changes

The following snap config options currently supported:
* `nvidia-support.disabled`
* `nvidia-support.runtime.config-override`
* `nvidia-support.cdi.device-name-strategy`