### PR TITLE
Provide content slots for ro/rw access to docker daemon config

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,6 +80,16 @@ plugs:
     # Currently, this is the only relevant provider, but cannot be default as not supported on all archs #
     #default-provider: nvidia-core22
 slots:
+  config:
+    interface: content
+    content: docker-config
+    write:
+      - $SNAP_DATA/config
+  config-ro:
+    interface: content
+    content: docker-config-ro
+    read:
+      - $SNAP_DATA/config
   docker-daemon:
     interface: docker
   docker-executables:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,11 +80,6 @@ plugs:
     # Currently, this is the only relevant provider, but cannot be default as not supported on all archs #
     #default-provider: nvidia-core22
 slots:
-  config:
-    interface: content
-    content: docker-config
-    write:
-      - $SNAP_DATA/config
   config-ro:
     interface: content
     content: docker-config-ro


### PR DESCRIPTION
There are use cases where another snap may want to either observe or modify the contents of daemon.json. One such case is azure-iot-edge, which does some networking diagnostics based on settings it reads from that file. It only needs read access, but it is also totally feasible that unattended IoT deployments may want to configure their daemon.json in certain ways and writing via a content interface would be one of the easier ways to do that.

No strong opinions on the naming, or whether these should be collapsed into a single R/W interface (as opposed to also having the R/O version)