### PR TITLE
build: compile docker-cli statically

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -322,7 +322,7 @@ parts:
 
       # build the docker cli binary
       unset LDFLAGS
-      make dynbinary
+      make binary
 
       install -d "$CRAFT_PART_INSTALL/bin"
       install -T build/docker "$CRAFT_PART_INSTALL/bin/docker"


### PR DESCRIPTION
Compile `docker-cli` statically to avoid problems described on #132.  

Currently, the `docker-snap` is shipped with the `docker-cli` dynamically linked: 
```bash
lincoln@fenrir:~/docker/multiarch/dynamic/amd64$ ldd bin/docker
        linux-vdso.so.1 (0x00007ffc5850a000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000719048400000)
        /lib64/ld-linux-x86-64.so.2 (0x000071904a179000)
```

When shipping a companion snap based on core 20 or an older version, we encounter `GLIBC` problems due to incompatible versions: 

```bash
lincoln@fenrir:~/docker/rocker$ sudo rocker hello-world
docker: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by docker)
docker: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by docker)
```
**Note**: "Companion snap" refers to the snap that is compiled to wrap docker and use it in systems like Ubuntu Core.

The static compilation of `docker-cli` aims to avoid `GLIBC` problems with compatibility between `docker-snap` and other snaps based on legacy core versions.